### PR TITLE
Improve edit hints to encourage incremental changes (v1.6.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-semantic-mcp",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Semantic MCP server for Obsidian - AI-optimized interface with 5 intelligent operations",
   "private": false,
   "type": "module",

--- a/src/config/workflows.json
+++ b/src/config/workflows.json
@@ -181,7 +181,7 @@
       "description": "Smart editing operations",
       "actions": {
         "window": {
-          "description": "Edit with fuzzy matching",
+          "description": "Edit with fuzzy matching - make small, incremental changes",
           "success_hints": {
             "message": "Replaced text at line {line}",
             "suggested_next": [
@@ -189,19 +189,19 @@
                 "condition": "always",
                 "suggestions": [
                   {
-                    "description": "Continue editing this file",
-                    "command": "edit(action='window', path='{path}', ...)",
-                    "reason": "Make more changes"
-                  },
-                  {
-                    "description": "View changes in context",
+                    "description": "Save and verify your changes",
                     "command": "view(action='window', path='{path}', line={line})",
-                    "reason": "Verify edit"
+                    "reason": "IMPORTANT: Always verify edits before making more changes"
                   },
                   {
-                    "description": "Search for similar patterns",
-                    "command": "vault(action='search', query='{old_text}')",
-                    "reason": "Find other occurrences"
+                    "description": "Make another small edit",
+                    "command": "edit(action='window', path='{path}', ...)",
+                    "reason": "Keep edits small and incremental - avoid large replacements"
+                  },
+                  {
+                    "description": "Open in Obsidian to see full context",
+                    "command": "view(action='open_in_obsidian', path='{path}')",
+                    "reason": "Review changes in the full editor"
                   }
                 ]
               }
@@ -366,11 +366,20 @@
   "efficiency_rules": [
     {
       "pattern": "multiple_edits_same_file",
-      "hint": "Consider batching edits to the same file to reduce tool calls"
+      "hint": "Make small, incremental edits and save frequently - avoid large replacements"
+    },
+    {
+      "pattern": "large_edit_attempt",
+      "hint": "Break large edits into smaller chunks - edit one paragraph or section at a time",
+      "trigger": "window_edit_over_10_lines"
     },
     {
       "pattern": "recreate_existing_file",
       "hint": "File exists - use edit operations instead of delete + create"
+    },
+    {
+      "pattern": "full_file_replacement",
+      "hint": "NEVER replace entire file content - use incremental edits to preserve file integrity"
     },
     {
       "pattern": "search_after_create",


### PR DESCRIPTION
## Summary
- Updated edit window hints to encourage small, incremental changes
- Added explicit warnings against large edits and full file replacements
- Reordered suggestions to prioritize saving changes before making more edits

## Test plan
- [x] Built project successfully
- [x] Test that edit hints show updated messages
- [x] Verify AI agents receive guidance for incremental editing

This quick patch addresses the issue where AI agents attempt overly large edits. The updated hints guide agents to make smaller, more manageable changes and save their work frequently.

🤖 Generated with [Claude Code](https://claude.ai/code)